### PR TITLE
Fix/no group lookup

### DIFF
--- a/src/ITB/HL7/Format/HL7XMLv2.cls
+++ b/src/ITB/HL7/Format/HL7XMLv2.cls
@@ -571,6 +571,7 @@ ClassMethod IsGroupStart(pSegObj As EnsLib.EDI.Segment, pIOStream As %IO.I.Chara
 			
 			&sql(select DataValue into :lkuValue from Ens_Util.LookupTable where id=:lkuId)
 			set:SQLCODE'=0 dataValue=0
+			if SQLCODE=100 continue
 			
 			// only add additional groups where a lookup value has been found
 			if lkuValue'=""	{
@@ -620,6 +621,7 @@ ClassMethod IsGroupEnd(pSegObj As EnsLib.EDI.Segment, pIOStream As %IO.I.Charact
 			
 			&sql(select DataValue into :lkuValue from Ens_Util.LookupTable where id=:lkuId)
 			set:SQLCODE'=0 dataValue=0
+			if SQLCODE=100 continue
 			
 			// only add additional groups where a lookup value has been found
 			if lkuValue'=""	{

--- a/src/ITB/Info.cls
+++ b/src/ITB/Info.cls
@@ -56,11 +56,12 @@
 ///     <li>3.0   - Version for IRIS, Classes added in UDL, ITB.EnsPortal removed (not supported), added Installer manifest</li>
 ///     <li>3.1   - Installer fixed</li>
 ///     <li>3.2   - Fixed ITB.HL7.Format.HL7XMLv2, added support to unescape XML inside a CDATA block</li>
+///     <li>3.3   - Fixed ITB.HL7.Format.HL7XMLv2, fixed &lt;0&gt; HL7 XML Segment added when no group found in LookUp Table</li>
 /// </ul>
 Class ITB.Info Extends %RegisteredObject
 {
 
-Parameter VERSION = 3.2;
+Parameter VERSION = 3.3;
 
 Parameter PORTING = 2014;
 


### PR DESCRIPTION
Fixed ITB.HL7.Format.HL7XMLv2, fixed <0> HL7 XML Segment added when no group found in LookUp Table.
All UnitTests passed after this change.
The code now continues to search for the next HL7 Group if a match has not been found. (without this change it was entered a group with an erroneous tag <0>)