### PR TITLE
Handle XML before sending + sample with XSLT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 samples/input/*.xml
 samples/input/*.hl7
 samples/output/*.xml
+samples/output/xslt/*.xml
 samples/output/*.hl7*
 samples/log/*.xml
 samples/error/*.xml

--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="healthcare-hl7-xml.ZPM">
     <Module>
       <Name>healthcare-hl7-xml</Name>
-      <Version>3.4.0</Version>
+      <Version>3.5.0</Version>
       <Description>HealthCare HL7 XML eases the implementation of HL7 v.2.x in XML format using InterSystems technology</Description>
       <Keywords>xml interoperability hl7 iris healthconnect</Keywords>
       <Author>

--- a/src/ITB/HL7/BO/XMLOperation.cls
+++ b/src/ITB/HL7/BO/XMLOperation.cls
@@ -29,10 +29,13 @@ Method SendHL7XML(pRequest As EnsLib.HL7.Message, Output pResponse As EnsLib.HL7
 		// convert EnsLib.HL7.Message to XML
 		set tXML = ##class(ITB.HL7.Util.Convert).ER7ToXML(pRequest,.tSC,..MessageSchemaCategory,,,..StripNamespace)
 		if $$$ISERR(tSC) $$$ThrowStatus(tSC)
+
+		// call XML message handler before sending
+		$$$ThrowOnError(..HandleXMLBeforeSending(tXML, .tXMLToSend))
 		
 		// send XML through adapter
 		set tAckXML = ##class(%Stream.GlobalCharacter).%New()
-		$$$THROWONERROR(tSC, ..AdapterSendStream(tXML,.tAckXML))
+		$$$THROWONERROR(tSC, ..AdapterSendStream(tXMLToSend, .tAckXML))
 		
 		if pGetAck {
 			// show received XML
@@ -68,6 +71,13 @@ Method SendHL7XML(pRequest As EnsLib.HL7.Message, Output pResponse As EnsLib.HL7
 /// Send stream using Adapter (this method should be overwritten in derived operations)
 Method AdapterSendStream(pRequest As %Stream.Object, Output pResponse As %Stream.Object) As %Status
 {
+}
+
+/// Handle XML before sending. This method can be overridden to perform transformations in XML before sending message.
+Method HandleXMLBeforeSending(pXML As %Stream.Object, Output pXMLToSend As %Stream.Object) As %Status
+{
+	set pXMLToSend = pXML
+	quit $$$OK
 }
 
 /// Return an array of connections for drawing lines on the config diagram

--- a/src/ITB/Info.cls
+++ b/src/ITB/Info.cls
@@ -37,11 +37,12 @@
 ///     <li>3.2   - Fixed ITB.HL7.Format.HL7XMLv2, added support to unescape XML inside a CDATA block</li>
 ///     <li>3.3   - Fixed ITB.HL7.Format.HL7XMLv2, fixed &lt;0&gt; HL7 XML Segment added when no group found in LookUp Table</li>
 ///     <li>3.4   - Added support for zpm. Supported versions are now only >= 2020</li>
+///     <li>3.5   - Added HandleXMLBeforeSending callback for operations, so it can be overridden to transform XML before sending message</li>
 /// </ul>
 Class ITB.Info Extends %RegisteredObject
 {
 
-Parameter VERSION = 3.4;
+Parameter VERSION = 3.5;
 
 Parameter PORTING = 2014;
 

--- a/src/ITB/Production/Sample/FileXMLOperationXSLT.cls
+++ b/src/ITB/Production/Sample/FileXMLOperationXSLT.cls
@@ -1,0 +1,33 @@
+/// 
+/// This is an simple example of an operation that transforms HL7 XML using XSLT before sending the message
+/// See ITB.Production.Sample.SimpleXSLT for XSLT sample.
+Class ITB.Production.Sample.FileXMLOperationXSLT Extends ITB.HL7.BO.FileXMLOperation
+{
+
+/// Class name which contains an XData block with XSLT
+Property XSLTClass As %String(MAXLEN = 255);
+
+/// Name of the XData block which contains XSLT
+Property XSLTXData As %String(MAXLEN = 255);
+
+Parameter SETTINGS = "XSLTClass:XSLT,XSLTXData:XSLT";
+
+/// Handle XML before sending. This method can be overridden to perform transformations in XML before sending message.
+Method HandleXMLBeforeSending(pXML As %Stream.Object, Output pXMLToSend As %Stream.Object) As %Status
+{
+	set ret = $$$OK
+    try {
+        set pXMLToSend = ##class(%Stream.GlobalCharacter).%New()
+       
+        // open XSLT XData
+        Set tXSLT = ##class(%Dictionary.CompiledXData).%OpenId(..XSLTClass_"||"_..XSLTXData).Data
+        // transform XML using XSLT
+        $$$ThrowOnError(##class(%XML.XSLT.Transformer).TransformStream(pXML, tXSLT, .pXMLToSend))
+
+    } catch ex {
+        set ret = ex.AsStatus()
+    }
+    quit ret
+}
+
+}

--- a/src/ITB/Production/Sample/SimpleXSLT.cls
+++ b/src/ITB/Production/Sample/SimpleXSLT.cls
@@ -1,0 +1,19 @@
+/// Simple XSLT that replace ORM_O01.ORDER_DETAIL for TRANSFORMED.ORDER_DETAIL
+Class ITB.Production.Sample.SimpleXSLT Extends %RegisteredObject
+{
+
+XData XSLT
+{
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()" />
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="ORM_O01.ORDER_DETAIL">
+        <TRANSFORMED.ORDER_DETAIL><xsl:apply-templates select="@*|node()" /></TRANSFORMED.ORDER_DETAIL>
+    </xsl:template>
+</xsl:stylesheet>
+}
+
+}

--- a/src/ITB/Production/TestXMLHL7File.cls
+++ b/src/ITB/Production/TestXMLHL7File.cls
@@ -22,13 +22,21 @@ XData ProductionDefinition
     <Setting Target="Host" Name="MessageSchemaCategory">ITB</Setting>
   </Item>
   <Item Name="HL7FileER7Service" Category="" ClassName="EnsLib.HL7.Service.FileService" PoolSize="1" Enabled="true" Foreground="false" Comment="" LogTraceEvents="false" Schedule="">
-    <Setting Target="Host" Name="TargetConfigNames">HL7FileXMLOperation,HL7FileER7Operation</Setting>
+    <Setting Target="Host" Name="TargetConfigNames">HL7FileXMLOperation,HL7FileER7Operation,HL7FileXMLOperationXSLT</Setting>
     <Setting Target="Adapter" Name="FilePath">/app/samples/input</Setting>
     <Setting Target="Adapter" Name="FileSpec">*.hl7</Setting>
     <Setting Target="Host" Name="MessageSchemaCategory">ITB</Setting>
   </Item>
   <Item Name="HL7FileER7Operation" Category="" ClassName="EnsLib.HL7.Operation.FileOperation" PoolSize="1" Enabled="true" Foreground="false" Comment="" LogTraceEvents="false" Schedule="">
     <Setting Target="Adapter" Name="FilePath">/app/samples/output</Setting>
+  </Item>
+  <Item Name="HL7FileXMLOperationXSLT" Category="" ClassName="ITB.Production.Sample.FileXMLOperationXSLT" PoolSize="1" Enabled="true" Foreground="false" Comment="" LogTraceEvents="true" Schedule="">
+    <Setting Target="Adapter" Name="FilePath">/app/samples/output/xslt</Setting>
+    <Setting Target="Host" Name="ArchiveIO">1</Setting>
+    <Setting Target="Adapter" Name="Charset">UTF-8</Setting>
+    <Setting Target="Host" Name="MessageSchemaCategory">ITB</Setting>
+    <Setting Target="Host" Name="XSLTClass">ITB.Production.Sample.SimpleXSLT</Setting>
+    <Setting Target="Host" Name="XSLTXData">XSLT</Setting>
   </Item>
 </Production>
 }


### PR DESCRIPTION
Added callback in XMLOperation to allow handling XML before sending message.


This will allow to implement derived operations that could transform XML using XSLT before sending the message.